### PR TITLE
Final Merge Request

### DIFF
--- a/Client/GameCoding/ClientPacketHandler.cpp
+++ b/Client/GameCoding/ClientPacketHandler.cpp
@@ -278,6 +278,9 @@ void ClientPacketHandler::Handle_S_Hit(ServerSessionRef session, BYTE* buffer, i
 	if (creature == nullptr)
 		return;
 
+	if (damage <= 0)
+		return;
+
 	if (creature->info.objecttype() == Protocol::OBJECT_TYPE_MONSTER)
 	{
 		GET_SINGLE(SoundManager)->Play(L"MonsterOnDamaged");
@@ -291,6 +294,10 @@ void ClientPacketHandler::Handle_S_Hit(ServerSessionRef session, BYTE* buffer, i
 	auto maxhp = creature->info.maxhp();
 
 	creature->info.set_hp(clamp(hp - damage, 0, maxhp));
+	if (creature->info.hp() <= 0)
+	{
+		scene->RemoveActor(creature);
+	}
 }
 
 void ClientPacketHandler::Handle_S_Fire(ServerSessionRef session, BYTE* buffer, int32 len)

--- a/Client/GameCoding/Creature.cpp
+++ b/Client/GameCoding/Creature.cpp
@@ -32,13 +32,40 @@ void Creature::Render(HDC hdc)
 	Super::Render(hdc);
 }
 
-void Creature::KnockBack()
+void Creature::KnockBack(Protocol::DIR_TYPE dir)
 {
-	Vec2Int backPos = GetBehindCellPos();
+	Vec2Int cellPos = {};
 
-	// 캐릭터가 몬스터를 때릴때 몬스터만 넉백됨
-	if (CanGo(backPos))
-		SetCellPos(backPos, true);
+	// 상대가 바라보는 방향으로 넉백 당함
+	switch (dir)
+	{
+	case DIR_UP:
+		cellPos = { 0, -1 };
+		break;
+
+	case DIR_DOWN:
+		cellPos = { 0, 1 };
+		break;
+
+	case DIR_LEFT:
+		cellPos = { -1, 0 };
+		break;
+
+	case DIR_RIGHT:
+		cellPos = { 1, 0 };
+		break;
+
+	default:
+		cellPos = { 0, 0 };
+		break;
+	}
+
+	Vec2Int newPos = GetCellPos() + cellPos;
+
+	if (CanGo(newPos))
+	{
+		SetCellPos(newPos, true);
+	}
 }
 
 bool Creature::IsSafeZone(Vec2Int cellPos)

--- a/Client/GameCoding/Creature.h
+++ b/Client/GameCoding/Creature.h
@@ -17,7 +17,7 @@ public:
 	virtual void TickSkill()  override {};
 	virtual void UpdateAnimation()  override {};
 	
-	virtual void KnockBack();
+	virtual void KnockBack(Protocol::DIR_TYPE dir);
 	uint64 SetWait(uint64 time) { return _wait = GetTickCount64() + time; }
 
 	virtual bool IsSafeZone(Vec2Int cellPos);

--- a/Client/GameCoding/GameCoding.vcxproj.filters
+++ b/Client/GameCoding/GameCoding.vcxproj.filters
@@ -347,9 +347,6 @@
     <ClInclude Include="QuestManager.h">
       <Filter>소스 파일\01. Manager</Filter>
     </ClInclude>
-    <ClInclude Include="MerchantDialogueUI.h">
-      <Filter>소스 파일\06. UI\InGame\NPC</Filter>
-    </ClInclude>
     <ClInclude Include="PopUp.h">
       <Filter>소스 파일\06. UI\Base</Filter>
     </ClInclude>
@@ -385,6 +382,9 @@
     </ClInclude>
     <ClInclude Include="ProjectileRock.h">
       <Filter>소스 파일\03. Objects\Game\Projectile</Filter>
+    </ClInclude>
+    <ClInclude Include="MerchantDialogueUI.h">
+      <Filter>소스 파일\06. UI\InGame\Quest</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -621,9 +621,6 @@
     <ClCompile Include="QuestManager.cpp">
       <Filter>소스 파일\01. Manager</Filter>
     </ClCompile>
-    <ClCompile Include="MerchantDialogueUI.cpp">
-      <Filter>소스 파일\06. UI\InGame\NPC</Filter>
-    </ClCompile>
     <ClCompile Include="PopUp.cpp">
       <Filter>소스 파일\06. UI\Base</Filter>
     </ClCompile>
@@ -668,6 +665,9 @@
     </ClCompile>
     <ClCompile Include="ProjectileRock.cpp">
       <Filter>소스 파일\03. Objects\Game\Projectile</Filter>
+    </ClCompile>
+    <ClCompile Include="MerchantDialogueUI.cpp">
+      <Filter>소스 파일\06. UI\InGame\Quest</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Client/GameCoding/ItemManager.cpp
+++ b/Client/GameCoding/ItemManager.cpp
@@ -139,6 +139,11 @@ bool ItemManager::RemoveItemFromInventory(int itemId)
     return GetInventory()->RemoveItem(itemId);
 }
 
+bool ItemManager::RemoveItemFromInventory(int itemId, int counts)
+{
+    return GetInventory()->RemoveItem(itemId, counts);
+}
+
 void ItemManager::SetItemToQuickSlot(shared_ptr<ITEM> item, int index)
 {
     GetQuickSlot()->SetQuickSlot(item, index);
@@ -219,6 +224,7 @@ void ItemManager::OpenInventory()
 {
     if (_inventory->GetVisible())
     {
+        _inventory->ResetPos();
         _inventory->SetVisible(false);
     }
     else

--- a/Client/GameCoding/ItemManager.h
+++ b/Client/GameCoding/ItemManager.h
@@ -23,6 +23,7 @@ public:
 	bool AddItemToInventory(int itemId, int counts);
 	bool SetItemToInventory(int itemId, int counts);
 	bool RemoveItemFromInventory(int itemId);
+	bool RemoveItemFromInventory(int itemId, int counts);
 
 	shared_ptr<class QuickSlot> GetQuickSlot() { return _quickSlot; }
 	void SetItemToQuickSlot(struct shared_ptr<ITEM> item, int index);

--- a/Client/GameCoding/MerchantDialogueUI.cpp
+++ b/Client/GameCoding/MerchantDialogueUI.cpp
@@ -389,7 +389,7 @@ void MerchantDialogueUI::OnClickConfirmButton()
 						if (GET_SINGLE(ItemManager)->IsInventoryFull()
 							|| itemCount > maxCount)
 						{
-							// 인벤토리가 가득 차(찰 예정이라)서 퀘스트 완료 불가 -> 추후 코드 수정필요
+							// 인벤토리가 가득 차(찰 예정이라)서 퀘스트 완료 불가
 							return;
 						}
 					}
@@ -413,6 +413,16 @@ void MerchantDialogueUI::OnClickConfirmButton()
 				{
 					SendBufferRef sendBuffer = ClientPacketHandler::Make_C_QuestFinish(myPlayerId, _questID);
 					GET_SINGLE(NetworkManager)->SendPacket(sendBuffer);
+				}
+
+				// 아이템 퀘스트 완료 후 아이템 제거
+				auto quest = scene->GetQuest(_questID);
+				auto targetType = quest.targettype();
+				auto targetID = quest.targetid();
+				auto targetNums = quest.targetnums();
+				if (targetType == Protocol::OBJECT_TYPE_ITEM)
+				{
+					GET_SINGLE(ItemManager)->RemoveItemFromInventory(targetID, targetNums);
 				}
 			}
 		}

--- a/Client/GameCoding/Player.cpp
+++ b/Client/GameCoding/Player.cpp
@@ -84,13 +84,6 @@ void Player::BeginPlay()
 void Player::Tick()
 {
 	Super::Tick();
-
-	auto scene = GET_SINGLE(SceneManager)->GetDevScene();
-
-	if (info.hp() <= 0)
-	{
-		scene->RemoveActor(shared_from_this());
-	}
 }
 
 void Player::Render(HDC hdc)
@@ -178,7 +171,7 @@ void Player::TickSkill()
 
 				monster->SetWait(50);
 				monster->SetState(HIT);
-				monster->KnockBack();
+				monster->KnockBack(info.dir());
 			}
 		}
 		else if (GetWeaponType() == Protocol::WEAPON_TYPE_BOW)
@@ -256,7 +249,7 @@ void Player::TickSpin()
 
 				monster->SetWait(50);
 				monster->SetState(HIT);
-				monster->KnockBack();
+				monster->KnockBack(info.dir());
 			}
 
 			if (monster2)
@@ -272,7 +265,7 @@ void Player::TickSpin()
 
 				monster2->SetWait(50);
 				monster2->SetState(HIT);
-				monster2->KnockBack();
+				monster2->KnockBack(info.dir());
 			}
 
 			if (monster3)
@@ -288,7 +281,7 @@ void Player::TickSpin()
 
 				monster3->SetWait(50);
 				monster3->SetState(HIT);
-				monster3->KnockBack();
+				monster3->KnockBack(info.dir());
 			}
 
 			if (monster4)
@@ -304,7 +297,7 @@ void Player::TickSpin()
 
 				monster4->SetWait(50);
 				monster4->SetState(HIT);
-				monster4->KnockBack();
+				monster4->KnockBack(info.dir());
 			}
 		}
 		SetState(MOVE);

--- a/Server/Creature.cpp
+++ b/Server/Creature.cpp
@@ -80,15 +80,39 @@ void Creature::OnDamaged(CreatureRef attacker, bool debug)
 	// 사망 로직은 자식 클래스에서 수행
 }
 
-void Creature::KnockBack()
+void Creature::KnockBack(Protocol::DIR_TYPE dir)
 {
-	// 플레이어가 몬스터를 바라보는 방향
-	Vec2Int backPos = GetBackCellPos();
+	Vec2Int cellPos = {};
 
-	// 캐릭터가 몬스터를 때릴때 몬스터만 넉백됨
-	if (CanGo(backPos))
+	// 상대가 바라보는 방향으로 넉백 당함
+	switch (dir)
 	{
-		SetCellPos(backPos);
+	case DIR_UP:
+		cellPos = { 0, -1 };
+		break;
+
+	case DIR_DOWN:
+		cellPos = { 0, 1 };
+		break;
+
+	case DIR_LEFT:
+		cellPos = { -1, 0 };
+		break;
+
+	case DIR_RIGHT:
+		cellPos = { 1, 0 };
+		break;
+
+	default:
+		cellPos = { 0, 0 };
+		break;
+	}
+
+	Vec2Int newPos = GetCellPos() + cellPos;
+
+	if (CanGo(newPos))
+	{
+		SetCellPos(newPos);
 		_waitUntil = GetTickCount64() + 1000;
 	}
 }

--- a/Server/Creature.h
+++ b/Server/Creature.h
@@ -13,7 +13,7 @@ public:
 	virtual void Tick() override;
 
 	virtual void OnDamaged(CreatureRef attacker, bool debug = false);
-	virtual void KnockBack();
+	virtual void KnockBack(Protocol::DIR_TYPE dir);
 	uint64 SetWait(uint64 time) { return _waitHit = GetTickCount64() + time; }
 	wstring GetName();
 

--- a/Server/GameRoom.cpp
+++ b/Server/GameRoom.cpp
@@ -126,7 +126,7 @@ void GameRoom::Update()
 		item.second->Update();
 
 		auto id = item.second->GetObjectID();
-		// 어딘가에 적중시 제거
+		
 		if (item.second->info.hp() <= 0)
 		{
 			_temps[id] = item.second;

--- a/Server/Inventory.cpp
+++ b/Server/Inventory.cpp
@@ -106,7 +106,7 @@ void Inventory::EquipItem(int itemID, bool equip)
         }
         else
         {
-            _equips[1].itemID = itemID;
+            _equips[1].itemID = 0;
             _equips[1].itemCounts = 0;
         }
         break;
@@ -120,7 +120,7 @@ void Inventory::EquipItem(int itemID, bool equip)
         }
         else
         {
-            _equips[2].itemID = itemID;
+            _equips[2].itemID = 0;
             _equips[2].itemCounts = 0;
         }
         break;
@@ -134,7 +134,7 @@ void Inventory::EquipItem(int itemID, bool equip)
         }
         else
         {
-            _equips[3].itemID = itemID;
+            _equips[3].itemID = 0;
             _equips[3].itemCounts = 0;
         }
         break;
@@ -148,7 +148,7 @@ void Inventory::EquipItem(int itemID, bool equip)
         }
         else
         {
-            _equips[4].itemID = itemID;
+            _equips[4].itemID = 0;
             _equips[4].itemCounts = 0;
         }
         break;

--- a/Server/Monster.cpp
+++ b/Server/Monster.cpp
@@ -137,19 +137,19 @@ void Monster::UpdateIdle()
 		switch (randValue)
 		{
 		case 1:
-			SetDir(DIR_UP, true);
+			SetDir(DIR_UP);
 			break;
 
 		case 2:
-			SetDir(DIR_DOWN, true);
+			SetDir(DIR_DOWN);
 			break;
 
 		case 3:
-			SetDir(DIR_LEFT, true);
+			SetDir(DIR_LEFT);
 			break;
 
 		case 4:
-			SetDir(DIR_RIGHT, true);
+			SetDir(DIR_RIGHT);
 			break;
 		}
 
@@ -186,7 +186,7 @@ void Monster::UpdateIdle()
 							SetCellPos(nextPos);
 							_waitUntil = GetTickCount64() + 1000; // 1초 기다림
 
-							SetState(MOVE);
+							SetState(MOVE, true);
 						}
 					}
 					else
@@ -405,12 +405,9 @@ wstring Monster::GetName()
 	return GET_SINGLE(ItemManager)->StringToWString(info.name());
 }
 
-void Monster::KnockBack()
+void Monster::KnockBack(Protocol::DIR_TYPE dir)
 {
-	Super::KnockBack();
-
-	// 몬스터의 경우 넉백당하면 타겟을 리셋
-	_target.reset();
+	Super::KnockBack(dir);
 }
 
 void Monster::MonsterQuestProgress(PlayerRef player)

--- a/Server/Monster.h
+++ b/Server/Monster.h
@@ -25,7 +25,7 @@ public:
 	virtual void OnDamaged(CreatureRef attacker, bool debug = false) override;
 	uint64 SetWait(uint64 time) { return _waitHit = GetTickCount64() + time; }
 	wstring GetName();
-	virtual void KnockBack() override;
+	virtual void KnockBack(Protocol::DIR_TYPE dir) override;
 	void MonsterQuestProgress(PlayerRef player);
 
 	void SetInitialPos(Vec2Int pos) { _initialPos = pos; }

--- a/Server/Octoroc.cpp
+++ b/Server/Octoroc.cpp
@@ -108,19 +108,19 @@ void Octoroc::UpdateIdle()
 		switch (randValue)
 		{
 		case 1:
-			SetDir(DIR_UP, true);
+			SetDir(DIR_UP);
 			break;
 
 		case 2:
-			SetDir(DIR_DOWN, true);
+			SetDir(DIR_DOWN);
 			break;
 
 		case 3:
-			SetDir(DIR_LEFT, true);
+			SetDir(DIR_LEFT);
 			break;
 
 		case 4:
-			SetDir(DIR_RIGHT, true);
+			SetDir(DIR_RIGHT);
 			break;
 		}
 
@@ -157,7 +157,7 @@ void Octoroc::UpdateIdle()
 							SetCellPos(nextPos);
 							_waitUntil = GetTickCount64() + 1000; // 1초 기다림
 
-							SetState(MOVE);
+							SetState(MOVE, true);
 						}
 					}
 					else

--- a/Server/Player.cpp
+++ b/Server/Player.cpp
@@ -136,7 +136,7 @@ void Player::UpdateSkill()
 				return;
 
 			creature->SetWait(50);
-			creature->KnockBack();
+			creature->KnockBack(info.dir());
 		}
 	}
 	else if (info.weapontype() == Protocol::WEAPON_TYPE_BOW)
@@ -181,7 +181,7 @@ void Player::UpdateSpin()
 				session->Send(sendBuffer);
 			}
 			creature->SetWait(50);
-			creature->KnockBack();
+			creature->KnockBack(info.dir());
 		}
 
 		if (creature2)
@@ -200,7 +200,7 @@ void Player::UpdateSpin()
 				session->Send(sendBuffer);
 			}
 			creature2->SetWait(50);
-			creature2->KnockBack();
+			creature2->KnockBack(info.dir());
 		}
 
 		if (creature3)
@@ -219,7 +219,7 @@ void Player::UpdateSpin()
 				session->Send(sendBuffer);
 			}
 			creature3->SetWait(50);
-			creature3->KnockBack();
+			creature3->KnockBack(info.dir());
 		}
 
 		if (creature4)
@@ -239,7 +239,7 @@ void Player::UpdateSpin()
 				session->Send(sendBuffer);
 			}
 			creature4->SetWait(50);
-			creature4->KnockBack();
+			creature4->KnockBack(info.dir());
 		}
 	}
 	SetState(MOVE);


### PR DESCRIPTION
1. 기능 수정
- 넉백 알고리즘 변경

2. 버그 패치
- 방어력이 적의 공격력보다 높을 때 투사체에 맞으면 체력이 회복되던 버그 수정
- 장착 아이템 효과가 즉시 적용되지 않던 버그 수정
- 인벤토리 내 아이템 설명창의 위치가 리셋되지 않는 버그 수정
- 아이템 탈착을 서버에서 반영하고 있지 않던 버그 수정
- 아이템 요구 퀘스트 완료 후 아이템 보유량이 감소하지 않던 버그 수정
- 멀티 플레이에서 전투 시 플레이어 간 동기화가 적절히 이루어지지 않는 버그 수정
- 멀티 플레이에서 다른 플레이어가 사망 후 부활했을 때 즉시 사망한 것처럼 보이는 버그 수정